### PR TITLE
#11 [개선] 기본 로그인 아이디 이메일 형식으로 변경

### DIFF
--- a/src/main/java/com/example/intermediate/controller/request/LoginRequestDto.java
+++ b/src/main/java/com/example/intermediate/controller/request/LoginRequestDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class LoginRequestDto {
 
   @NotBlank
-  private String nickname;
+  private String emailId;
 
   @NotBlank
   private String password;

--- a/src/main/java/com/example/intermediate/controller/request/MemberRequestDto.java
+++ b/src/main/java/com/example/intermediate/controller/request/MemberRequestDto.java
@@ -12,6 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberRequestDto {
 
+  @NotBlank(message = "{member.emailId.notblank}")
+  @Pattern(regexp = "^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$", message = "{member.emailId.pattern}")
+  private String emailId;
+
   @NotBlank(message = "{member.nickname.notblank}")
   @Size(min = 4, max = 12, message = "{member.nickname.size}")
   @Pattern(regexp = "[a-z\\d]*${3,12}", message = "{member.nickname.pattern}")

--- a/src/main/java/com/example/intermediate/controller/response/MemberResponseDto.java
+++ b/src/main/java/com/example/intermediate/controller/response/MemberResponseDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberResponseDto {
   private Long id;
+  private String emailId;
   private String nickname;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;

--- a/src/main/java/com/example/intermediate/domain/Member.java
+++ b/src/main/java/com/example/intermediate/domain/Member.java
@@ -26,6 +26,9 @@ public class Member extends Timestamped {
   private Long id;
 
   @Column(nullable = false)
+  private String emailId;
+
+  @Column(nullable = false)
   private String nickname;
 
   @Column(nullable = false)

--- a/src/main/java/com/example/intermediate/repository/MemberRepository.java
+++ b/src/main/java/com/example/intermediate/repository/MemberRepository.java
@@ -8,4 +8,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findById(Long id);
   Optional<Member> findByNickname(String nickname);
+  Optional<Member> findByEmailId(String emailId);
 }


### PR DESCRIPTION
## What is this PR? :mag:
아이디 형식 이메일로 변경

## Changes :memo:
- emailId로 이메일 형식 아이디 추가
- 기존에 사용하던 nickname은 사용자 유저닉네임으로 사용
- 로그인 시 이메일 아이디로 로그인

## Comment
단순하게 회원가입 로그인때만 이메일 형식 아이디를 사용하게 하였습니다.
포스트나 코멘트 작성 시에는 유저 닉네임을 그대로 사용하도록 하였습니다.


